### PR TITLE
Use a retry decider function rather than a number of retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ Please note that this is a ES7 module, and needs to be transpiled by [Babel](htt
 ```js
 const r = require('requester')
 
-// Set how many times failing requests
-// should be retried (default: 2)
-r.retries(2)
-
 async function myFunction () {
   // Get a single url as json
   let json = await r.single('http://...')
@@ -44,11 +40,32 @@ async function myFunction () {
   // Error handling
   try {
 	let json = await r.single('http://...')
-  } catch (e) {
+  } catch (err) {
 	// Something went wrong :(
+	// err.response is the last response object (e.g. err.response.status)
+	// err.content is the parsed body of the response, if available
   }
 }
+```
 
+### Retry decider
+
+You can set a custom function that gets the current number of tries as well as
+the last error object to decide if the request should be retried. With the default settings,
+retrying is **disabled**.
+
+```js
+const r = require('requester')
+
+// Retry until we get a valid answer
+r.retry(() => true)
+
+// Try to get the answer a total of three times
+r.retry((tries) => tries <= 2)
+
+// Try to get the answer a total of three times if the
+// status code equals to "Internal Server Error"
+r.retry((tries, err) => tries <= 2 && err.response.status === 500)
 ```
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 const fetch = require('node-fetch')
 const async = require('async')
 
-let maxTries = 3
+let retryDecider = () => false
 
-// Set the maximum number of retries (default: 2)
-function retries (tries) {
-  maxTries = tries + 1
+// Set a custom decider function that decides to retry
+// based on the number of tries and the previous error
+function retry (decider) {
+  retryDecider = decider
 }
 
 // Request a single url
@@ -13,13 +14,13 @@ async function single (url, type = 'json') {
   let tries = 0
   let err
 
-  while (tries < maxTries) {
+  while (tries === 0 || retryDecider(tries, err)) {
     try {
       return await request(url, type)
     } catch (e) {
       err = e
+      tries += 1
     }
-    tries += 1
   }
 
   throw err
@@ -86,4 +87,4 @@ async function many (urls, type = 'json') {
   })
 }
 
-module.exports = {retries, single, many}
+module.exports = {retry, single, many}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "isparta": "^4.0.0",
     "mocha": "^2.3.4",
     "rewire": "^2.5.1",
+    "sinon": "^1.17.3",
     "snazzy": "^2.0.1"
   },
   "standard": {


### PR DESCRIPTION
- [x] The decider receives the number of tries and the last error
- [x] The requests get retries until a valid response is reached or the retry decider returns `false`

---

Reference: #3 