### PR TITLE
Support fetch headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,19 @@ npm install https://github.com/gw2efficiency/requester
 
 ## Usage
 
-Please note that this is a ES7 module, and needs to be transpiled by [Babel](https://github.com/babel/babel).
+Please note that this is a ES7 module and needs to be transpiled by [Babel](https://github.com/babel/babel).
 
 ```js
 const r = require('requester')
 
 async function myFunction () {
-  // Get a single url as json
+  // Get a single url
   let json = await r.single('http://...')
   // -> {foo: bar}
 	
-  // Get a single url as text
-  let html = await r.single('http://...', 'text')
-  // -> '<h1>html</h1>'
-	
-  // Get multiple urls as json
+  // Get multiple urls
   let json = await r.many(['http://...', 'http://...'])
   // -> [{foo: bar}, {foobar: 1}]
-	
-  // Get multiple urls as text
-  let json = await r.many(['http://...', 'http://...'], 'text')
-  // -> ['<h1>html</h1>', 'Maybe plain text']
 	
   // Error handling
   try {
@@ -46,6 +38,22 @@ async function myFunction () {
 	// err.content is the parsed body of the response, if available
   }
 }
+```
+
+### Options
+
+You can pass `single` and `many` an optional `options` parameter. 
+The available options with their corresponding defaults are:
+
+```js
+let options = {
+  type: 'json',   // response type, can be either "json" or "text"
+  method: 'GET',  // request method to use
+  headers: {},    // request headers, format {a:1} or {b:[1,2,3]}
+  body: null      // request body, can be a string or readable stream
+}
+
+await r.single('http://...', options)
 ```
 
 ### Retry decider

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -35,7 +35,7 @@ describe('requesting', () => {
       ['http://test.com/test', '<h1>Foo</h1>']
     ])
 
-    let content = await module.single('http://test.com/test', 'text')
+    let content = await module.single('http://test.com/test', {type: 'text'})
     expect(content).to.deep.equal('<h1>Foo</h1>')
   })
 
@@ -65,12 +65,43 @@ describe('requesting', () => {
       'http://test.com/test',
       'http://test.com/test2',
       'http://test.com/test3'
-    ], 'text')
+    ], {type: 'text'})
     expect(content).to.deep.equal([
       '<h1>Foo</h1>',
       '<h1>Foo</h1>',
       '<h1>FooBar</h1>'
     ])
+  })
+
+  it('provides "fetch" with the options', async () => {
+    mockResponses([
+      ['http://test.com/test', {id: 123}]
+    ])
+
+    let content = await module.single('http://test.com/test')
+    expect(content).to.deep.equal({id: 123})
+    expect(fetchMock.lastOptions()).to.deep.equal({
+      type: 'json',
+      method: 'GET',
+      headers: {},
+      body: null
+    })
+  })
+
+  it('can overwrite the default "fetch" options', async () => {
+    mockResponses([
+      ['http://test.com/test', '<h1>Foo</h1>']
+    ])
+
+    let options = {
+      type: 'text',
+      method: 'POST',
+      headers: {'Authentication': 'Test'},
+      body: 'foo=bar'
+    }
+    let content = await module.single('http://test.com/test', options)
+    expect(content).to.deep.equal('<h1>Foo</h1>')
+    expect(fetchMock.lastOptions()).to.deep.equal(options)
   })
 })
 
@@ -99,7 +130,7 @@ describe('error handling', () => {
       await module.many([
         'http://failing.com/no',
         'http://failing.com/yes'
-      ], 'text')
+      ], {type: 'text'})
     } catch (e) {
       var err = e
     }
@@ -171,7 +202,7 @@ describe('retrying', () => {
       }]
     ])
 
-    let content = await module.single('http://test.com/test', 'text')
+    let content = await module.single('http://test.com/test', {type: 'text'})
     expect(content).to.deep.equal('text')
     expect(tries).to.equal(4)
   })


### PR DESCRIPTION
- [x] Convert the `type` parameter into a `options` parameter
- [x] Give the `options` to `fetch`

---

Reference: #8 